### PR TITLE
Fix undefined method BigDecimal.new

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -108,7 +108,11 @@ class BigDecimal
   # raises TypeError exception. Checking here on the runtime whether BigDecimal
   # will allow dup or not.
   begin
-    BigDecimal.new('4.56').dup
+    if defined? BigDecimal.new
+      BigDecimal.new('4.56').dup
+    else
+      BigDecimal('4.56').dup
+    end
 
     def duplicable?
       true


### PR DESCRIPTION
From ruby version 2.7 onward this is not accepted anymore. Since support is trying to be kept for 1.9.x, keeping the old syntax here allows for backwards support

### Summary

Fixing bug `<class:BigDecimal>': undefined method new' for BigDecimal:Class (NoMethodError)` for rails 4.2.11.1 compatibility to ruby 2.7`